### PR TITLE
Exclude query string from mapping URI to file path

### DIFF
--- a/src/main/java/io/github/kitarek/elasthttpd/plugins/consumers/file/mapper/UriToFileMapper.java
+++ b/src/main/java/io/github/kitarek/elasthttpd/plugins/consumers/file/mapper/UriToFileMapper.java
@@ -17,6 +17,7 @@
 
 package io.github.kitarek.elasthttpd.plugins.consumers.file.mapper;
 
+import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -38,6 +39,7 @@ public class UriToFileMapper {
 	public static final Logger LOGGER = LoggerFactory.getLogger(UriToFileMapper.class);
 	public static final String ROOT_URI_REQUEST_PATH = "/";
 	public static final String RESOURCE_PATH_SEPARATOR = "/";
+	public static final String QUERY_STRING_REQUEST_PATH_SEPARATOR = "?";
 	private final String pathToMappedRootDirectory;
 
 	public UriToFileMapper(String pathToMappedRootDirectory) {
@@ -66,7 +68,11 @@ public class UriToFileMapper {
 
 	public String mapUriRequestPath(String uriRequestPath) {
 		isTrue(isCorrectUriRequestPath(uriRequestPath), "URI request path is not correct");
-		return removeEnd(pathToMappedRootDirectory + normalizeUrlRequestPath(uriRequestPath), RESOURCE_PATH_SEPARATOR);
+		return removeEnd(pathToMappedRootDirectory + getNormalizedUriRequestPathWithoutQueryString(uriRequestPath), RESOURCE_PATH_SEPARATOR);
+	}
+
+	public String getNormalizedUriRequestPathWithoutQueryString(String uriRequestPath) {
+		return normalizeUrlRequestPath(StringUtils.substringBefore(uriRequestPath, QUERY_STRING_REQUEST_PATH_SEPARATOR));
 	}
 
 	private String normalizeUrlRequestPath(String uriRequestPath) {

--- a/src/test/groovy/io/github/kitarek/elasthttpd/plugins/consumers/file/mapper/UriToFileMapperSpec.groovy
+++ b/src/test/groovy/io/github/kitarek/elasthttpd/plugins/consumers/file/mapper/UriToFileMapperSpec.groovy
@@ -173,7 +173,6 @@ class UriToFileMapperSpec extends Specification {
 			'/src/a/b/c%20'  | validExistingDirectory() | validExistingDirectory() + "/src/a/b/c "
 			'/src%21'        | validExistingDirectory() | validExistingDirectory() + "/src!"
 			'/src%2B'        | validExistingDirectory() | validExistingDirectory() + "/src+"
-
 	}
 
 	@Unroll("Maps specified relative URI request path: #requestedPath appropriatly always under rootDirectory")
@@ -197,6 +196,27 @@ class UriToFileMapperSpec extends Specification {
 			'/../src/../a/../b/c%2FD'  | validExistingDirectory() | validExistingDirectory() + "/b/c/D"
 			'/../src/../a/../b/c%2F'   | validExistingDirectory() | validExistingDirectory() + "/b/c"
 			'/../src/../a/../b/c%2C'   | validExistingDirectory() | validExistingDirectory() + "/b/c,"
+	}
+
+
+	@Unroll("Maps specified URI request path that contains query string: #requestedPath without applying query string as subpath of rootDirectory")
+	def 'Maps specified URI request path that contains query string without applying the query string part in subpath of rootDirectory'() {
+		given:
+			def UriToFileMapper mapper = new UriToFileMapper(root)
+
+		when:
+			def actualAbsoluteFilePath = mapper.mapUriRequestPath(requestedPath)
+
+		then:
+			actualAbsoluteFilePath == expectedMappedFilePath
+
+		where:
+			requestedPath            | root                     | expectedMappedFilePath
+			'/src?a=b'               | validExistingDirectory() | validExistingDirectory() + "/src"
+			'/src/a/b/c%20?c=d'      | validExistingDirectory() | validExistingDirectory() + "/src/a/b/c "
+			'/src/a/b/c%20?e=f&g=f'  | validExistingDirectory() | validExistingDirectory() + "/src/a/b/c "
+			'/src%21?d=f&j=k'        | validExistingDirectory() | validExistingDirectory() + "/src!"
+			'/src%2B?'               | validExistingDirectory() | validExistingDirectory() + "/src+"
 	}
 
 	@Shared


### PR DESCRIPTION
Fixed UriToFileMapper to exclude any query string in request path during mapping.
